### PR TITLE
remove hash syntax for ruby < 2

### DIFF
--- a/app/controllers/gatherable/application_controller.rb
+++ b/app/controllers/gatherable/application_controller.rb
@@ -3,15 +3,15 @@ module Gatherable
     before_action :authenticate, only: [:create]
 
     def show
-      render :json => model_class.find_by!(params.slice(model_id, global_identifier)), :status => :found
+      render json: model_class.find_by!(params.slice(model_id, global_identifier)), status: :found
     rescue ActiveRecord::RecordNotFound => e
-      render :json => { :errors => e.message}, :status => :not_found
+      render json: { errors: e.message}, status: :not_found
     end
 
     def create
-      render :json => model_class.create!(model_params), :status => :created
+      render json: model_class.create!(model_params), status: :created
     rescue StandardError => e
-      render :json => { :errors => e.message}, :status => :unprocessable_entity
+      render json: { errors: e.message}, status: :unprocessable_entity
     end
 
     private

--- a/app/writers/migration_writer.rb
+++ b/app/writers/migration_writer.rb
@@ -61,10 +61,10 @@ end
     <<-template
 class CreateGatherable#{table_name.classify} < ActiveRecord::Migration
   def up
-    create_table '#{Gatherable.config.schema_name}.#{table_name}', :primary_key => '#{data_table.name}_id' do |t|
+    create_table '#{Gatherable.config.schema_name}.#{table_name}', primary_key: '#{data_table.name}_id' do |t|
       #{migration_columns}
-      t.string :#{Gatherable.config.global_identifier}, :index => true
-      t.timestamps :null => false
+      t.string :#{Gatherable.config.global_identifier}, index: true
+      t.timestamps null: false
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Gatherable::Engine.routes.draw do
   Gatherable.config.data_tables.map{ |dp| dp.name.to_s.pluralize }.each do |data_table|
-    scope :path => "/:#{Gatherable.config.global_identifier}" do
-      resources data_table.to_sym, :only => [:show, :create], :param => "#{data_table.singularize}_id"
+    scope path: "/:#{Gatherable.config.global_identifier}" do
+      resources data_table.to_sym, only: [:show, :create], param: "#{data_table.singularize}_id"
     end
   end
 end

--- a/lib/gatherable/configuration.rb
+++ b/lib/gatherable/configuration.rb
@@ -1,6 +1,6 @@
 module Gatherable
   class Configuration
-    delegate :empty?, :to => :data_tables
+    delegate :empty?, to: :data_tables
     attr_accessor :global_identifier
     attr_writer :schema_name, :auth_method
 


### PR DESCRIPTION
Not sure if we really want to abandon 1.9.3 yet. 